### PR TITLE
Add baseline gathering script

### DIFF
--- a/doc/python-3.2.5/Baseline-Report.md
+++ b/doc/python-3.2.5/Baseline-Report.md
@@ -1,0 +1,15 @@
+# Baseline Test Report for Python 3.2.5
+
+This document collects the initial failures when running the `attrs` test suite under Python 3.2.5.
+
+If you are running this in an environment where Python 3.2.5 is available, execute the `run_baseline.py` script and copy the relevant parts of the output below.
+
+```bash
+$ python doc/python-3.2.5/run_baseline.py
+```
+
+The script stores the full test output in `doc/python-3.2.5/baseline/test-output.txt`.
+
+## Test Results
+
+*(Paste the summarized failures here.)*

--- a/doc/python-3.2.5/run_baseline.py
+++ b/doc/python-3.2.5/run_baseline.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Run the attrs test suite under Python 3.2.5 and capture output.
+
+This script must be executed using a Python 3.2.5 interpreter.
+It will run ``pytest`` and write the full output to
+``doc/python-3.2.5/baseline/test-output.txt``.
+"""
+
+from __future__ import print_function
+
+import os
+import sys
+import platform
+import subprocess
+
+
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "baseline")
+
+
+def main():
+    if not os.path.exists(OUTPUT_DIR):
+        os.makedirs(OUTPUT_DIR)
+
+    output_file = os.path.join(OUTPUT_DIR, "test-output.txt")
+
+    f = open(output_file, "w")
+    try:
+        f.write("Python executable: %s\n" % sys.executable)
+        f.write("Python version: %s\n" % platform.python_version())
+        f.write("Platform: %s\n\n" % platform.platform())
+        f.flush()
+
+        cmd = [sys.executable, "-m", "pytest", "-v"]
+        proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT)
+        proc.wait()
+        f.write("\nReturn code: %s\n" % proc.returncode)
+    finally:
+        f.close()
+
+    print("Baseline test output written to %s" % output_file)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a helper script to run tests using Python 3.2.5
- provide a Baseline-Report stub for documenting failures

## Testing
- `pyenv install -s 3.2.5` *(fails: The requested URL returned error: 403)*
- `uv run pytest -q` *(fails: unsuccessful tunnel while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6845324369408326a774ff74b8034c65