### PR TITLE
Port fixtures to old pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,13 +9,13 @@ from hypothesis import HealthCheck, settings
 from attr._compat import PY_3_10_PLUS
 
 
-@pytest.fixture(name="slots", params=(True, False))
-def _slots(request):
+@pytest.fixture(params=(True, False))
+def slots(request):
     return request.param
 
 
-@pytest.fixture(name="frozen", params=(True, False))
-def _frozen(request):
+@pytest.fixture(params=(True, False))
+def frozen(request):
     return request.param
 
 


### PR DESCRIPTION
## Summary
- support older pytest by removing `name` parameter to `pytest.fixture`

## Testing
- `pytest tests/test_setattr.py::TestSetAttr.test_setattr_reset_if_no_custom_setattr -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_b_68453a9a7b3483268f11cd10680ccfb1